### PR TITLE
feat: add StopListeningToTicks method to go-clients

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -17,6 +17,7 @@ import (
 	smaapi "github.com/cryptellation/sma/api"
 	smaclient "github.com/cryptellation/sma/pkg/clients"
 	ticksclient "github.com/cryptellation/ticks/pkg/clients"
+	"github.com/google/uuid"
 	temporalclient "go.temporal.io/sdk/client"
 	temporalLog "go.temporal.io/sdk/log"
 	"golang.org/x/sync/errgroup"
@@ -80,6 +81,14 @@ type Client interface {
 		ctx context.Context,
 		listener ticksclient.ListenerParams,
 		exchange, pair string,
+	) error
+
+	// StopListeningToTicks unregisters a callback workflow from ticks for a given exchange and pair.
+	StopListeningToTicks(
+		ctx context.Context,
+		listener uuid.UUID,
+		exchange string,
+		pair string,
 	) error
 
 	// ServicesInfo retrieves information about the services.

--- a/client/ticks.go
+++ b/client/ticks.go
@@ -4,15 +4,24 @@ import (
 	"context"
 
 	"github.com/cryptellation/ticks/pkg/clients"
+	"github.com/google/uuid"
 )
 
 // ListenToTicks listens to ticks from a specific exchange and trading pair.
-// Note: This method is deprecated. The new ticks client API requires a worker and task queue.
-// Use the ticks client directly with a worker for listening to ticks.
 func (c client) ListenToTicks(
 	ctx context.Context,
 	listener clients.ListenerParams,
 	exchange, pair string,
 ) error {
 	return c.ticks.ListenToTicks(ctx, listener, exchange, pair)
+}
+
+// StopListeningToTicks unregisters a callback workflow from ticks for a given exchange and pair.
+func (c client) StopListeningToTicks(
+	ctx context.Context,
+	listener uuid.UUID,
+	exchange string,
+	pair string,
+) error {
+	return c.ticks.StopListeningToTicks(ctx, listener, exchange, pair)
 }


### PR DESCRIPTION
- Add StopListeningToTicks method to ticks client implementation
- Update Client interface to include StopListeningToTicks method
- Add required uuid import for listener identification
- Enable unregistering tick listeners using RequesterID