### PR TITLE
fix(dependencies): update runtime to v1.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cryptellation/candlesticks v1.0.4
 	github.com/cryptellation/exchanges v1.1.1
 	github.com/cryptellation/forwardtests v1.1.1
-	github.com/cryptellation/runtime v1.7.0
+	github.com/cryptellation/runtime v1.8.0
 	github.com/cryptellation/sma v1.0.6
 	github.com/cryptellation/ticks v1.2.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/cryptellation/forwardtests v1.1.1 h1:amKOjLEqMJ3PDzhMpLPzXEOPih12Miih
 github.com/cryptellation/forwardtests v1.1.1/go.mod h1:qG240vFOEmGbctY/T9jHcNEJjB92/xcEzo5sGPJhPNM=
 github.com/cryptellation/runtime v1.7.0 h1:8qCi8nBAsjQyF1a2makR1JIHuI9jSSJBWGS1NRoRfWE=
 github.com/cryptellation/runtime v1.7.0/go.mod h1:EFaH6DdIGe4eEPsapFKK5uIJZNII7MIGT2eWjl09RYU=
+github.com/cryptellation/runtime v1.8.0 h1:N0271FOlLh559BPSMTFMz+odDONbKnNZ6Yt1B4yHFos=
+github.com/cryptellation/runtime v1.8.0/go.mod h1:EFaH6DdIGe4eEPsapFKK5uIJZNII7MIGT2eWjl09RYU=
 github.com/cryptellation/sma v1.0.6 h1:Jtgg83vWDEIw24srmBz5eRig4nlBde7ueAHRnNizLYc=
 github.com/cryptellation/sma v1.0.6/go.mod h1:NJ3dHno2Ra3yVeIoFuSK4LTWiQ5E6uqRayemLZIvgwg=
 github.com/cryptellation/ticks v1.2.1 h1:onvm8kmEyBxK5ELWrzUqqCd8+6BT3LhPfBmUP11J6Vo=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/runtime** to version **v1.8.0**.

### Changes
- Updated dependency: `github.com/cryptellation/runtime`
- New version: `v1.8.0`

This update was automatically generated by DepSync.