### PR TITLE
[DepSync] Update backtests to v1.2.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/cryptellation/go-clients
 go 1.23.8
 
 require (
-	github.com/cryptellation/backtests v1.1.2
-	github.com/cryptellation/candlesticks v1.0.4
+	github.com/cryptellation/backtests v1.2.4
+	github.com/cryptellation/candlesticks v1.1.0
 	github.com/cryptellation/exchanges v1.1.1
 	github.com/cryptellation/forwardtests v1.1.1
 	github.com/cryptellation/runtime v1.7.0
@@ -16,7 +16,7 @@ require (
 )
 
 require (
-	github.com/cryptellation/timeseries v1.1.0 // indirect
+	github.com/cryptellation/timeseries v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,12 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cryptellation/backtests v1.1.2 h1:2I9cyRC/FYGc8Em/uw+MYqvouy0OGUH6b5+UAmUdeNY=
 github.com/cryptellation/backtests v1.1.2/go.mod h1:UzHMaFRREe8pAdLIxkqa+/VfjtFwL4KbnPnYQpLU82A=
+github.com/cryptellation/backtests v1.2.4 h1:cJ8CxTAOCfht0LGxaeO9vRxuzs2HeoLjoyN1G5X8Dns=
+github.com/cryptellation/backtests v1.2.4/go.mod h1:iTk8Fieo70RdZJrD+ToAbgYseSz9RtK7FRoSY1xtuC4=
 github.com/cryptellation/candlesticks v1.0.4 h1:OSU4OyIH1+iVsIfEBEjf8vdKOleeLqW0agdl7DV9NYo=
 github.com/cryptellation/candlesticks v1.0.4/go.mod h1:0R+YZ+PBJsV+jindXAzTKfCU7kq+4VpUfKhWv+028GQ=
+github.com/cryptellation/candlesticks v1.1.0 h1:4l46/xInwGJxNFGCvFXDLmgrMkOJBu+R/l1o24JmzFk=
+github.com/cryptellation/candlesticks v1.1.0/go.mod h1:0lyK2y9RNKUOGnQFkeoyMCrkTuccdcnHXx4fndYVA8Y=
 github.com/cryptellation/exchanges v1.1.1 h1:bLXrfjKEAJGHasA8dROZTgiMQddRxZjdn6+XRecY/aM=
 github.com/cryptellation/exchanges v1.1.1/go.mod h1:2iyJgSid50L76UjS5gzV3hnCeq1DS4u/tkaJuq/toKY=
 github.com/cryptellation/forwardtests v1.1.1 h1:amKOjLEqMJ3PDzhMpLPzXEOPih12MiihSBYgBVueffo=
@@ -20,6 +24,8 @@ github.com/cryptellation/ticks v1.2.1 h1:onvm8kmEyBxK5ELWrzUqqCd8+6BT3LhPfBmUP11
 github.com/cryptellation/ticks v1.2.1/go.mod h1:tTMMu1U1e1I1J9Dp73KGh411TWrKcYmB4xORNJNPHtE=
 github.com/cryptellation/timeseries v1.1.0 h1:S5xFLGukQg+k22+L5151Na95+WjhhDKMK0hBkxfJYgo=
 github.com/cryptellation/timeseries v1.1.0/go.mod h1:SxqmKOjn/l5AXZGaLGA47oScXzpTcXtnmfom88uZdaY=
+github.com/cryptellation/timeseries v1.2.0 h1:x90TnFhE3H4zPWEgLLekPMG7t611cnFvNU9DnFyCiD0=
+github.com/cryptellation/timeseries v1.2.0/go.mod h1:SxqmKOjn/l5AXZGaLGA47oScXzpTcXtnmfom88uZdaY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/backtests** to version **v1.2.4**.

### Changes
- Updated dependency: `github.com/cryptellation/backtests`
- New version: `v1.2.4`

This update was automatically generated by DepSync.