### PR TITLE
chores(depsync): update github.com/cryptellation/exchanges to v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.8
 require (
 	github.com/cryptellation/backtests v1.1.2
 	github.com/cryptellation/candlesticks v1.1.0
-	github.com/cryptellation/exchanges v1.1.1
+	github.com/cryptellation/exchanges v1.2.0
 	github.com/cryptellation/forwardtests v1.2.0
 	github.com/cryptellation/runtime v1.7.0
 	github.com/cryptellation/sma v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/cryptellation/candlesticks v1.1.0 h1:4l46/xInwGJxNFGCvFXDLmgrMkOJBu+R
 github.com/cryptellation/candlesticks v1.1.0/go.mod h1:0lyK2y9RNKUOGnQFkeoyMCrkTuccdcnHXx4fndYVA8Y=
 github.com/cryptellation/exchanges v1.1.1 h1:bLXrfjKEAJGHasA8dROZTgiMQddRxZjdn6+XRecY/aM=
 github.com/cryptellation/exchanges v1.1.1/go.mod h1:2iyJgSid50L76UjS5gzV3hnCeq1DS4u/tkaJuq/toKY=
+github.com/cryptellation/exchanges v1.2.0 h1:PYhFhLz2d5ccaPAnzn3+4CCtKeTdzMPSFZVOgp9Aibw=
+github.com/cryptellation/exchanges v1.2.0/go.mod h1:6fO2AeYKdUSklP10oBdihV1Cl0cSNR/tGp362Llkw18=
 github.com/cryptellation/forwardtests v1.1.1 h1:amKOjLEqMJ3PDzhMpLPzXEOPih12MiihSBYgBVueffo=
 github.com/cryptellation/forwardtests v1.1.1/go.mod h1:qG240vFOEmGbctY/T9jHcNEJjB92/xcEzo5sGPJhPNM=
 github.com/cryptellation/forwardtests v1.2.0 h1:QSGZFU8PWlkMHtqs9E0VVBrnKjcchwno+0zShTysucE=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/exchanges** to version **v1.2.0**.

### Changes
- Updated dependency: `github.com/cryptellation/exchanges`
- New version: `v1.2.0`

This update was automatically generated by DepSync.